### PR TITLE
Speed up decode function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -116,7 +116,7 @@ def decode_netout(netout, obj_threshold, nms_threshold, anchors, nb_class):
                 # from 4th element onwards are confidence and class classes
                 classes = netout[row,col,b,5:]
                 
-                if np.sum(classes) > 0:
+                if classes.any():
                     # first 4 elements are x, y, w, and h
                     x, y, w, h = netout[row,col,b,:4]
 


### PR DESCRIPTION
On my machine `decode_netout` was taking about the same amount of time to run as the network itself, so I looked for ways to speed it up.  I tested a few vectorizations, which didn't do much, but I found one very simple change that makes a big difference.  On my machine, with a 54-class model, it reduced the average time for the `decode_netout` function from about 30ms to 16ms.

There is a test to check whether each box has any class confidences that exceed the detection threshold.  I profiled the `decode_netout` function and found that it is the most computationally expensive line.

The test is currently

```
if np.sum(classes) > 0:
```

Which will be true if any of the elements of `classes` are >0.  The values of classes were previously multiplied with a boolean indicator to eliminate values below the threshold.  I replaced that expression with an equivalent one that is faster:

```
if classes.any():
```

I believe that the two are equivalent because `classes` is the result of a softmax operation, so everything should be >= 0.